### PR TITLE
Corrected MAC address checking for Discovery mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ The Xiaomi Mi sensor provides temperature and humidity over BLE.
 
 This script also supports the ATC custom firmware!
 
+This is updated version of script forked from [erdose](https://github.com/erdose/xiaomi-mi-lywsd03mmc), which works correctly with custom [ATC software](https://github.com/pvvx/ATC_MiThermometer).
+Be sure to select [atc1441 format](https://github.com/atc1441/ATC_MiThermometer#advertising-format-of-the-custom-firmware).
+
 ![xiaomi_mi_2](Pictures/mi-temperature-and-humidity-monitor-2.jpg)
 
 ## How it works

--- a/xiaomiBleLywsd03mmc.py
+++ b/xiaomiBleLywsd03mmc.py
@@ -37,6 +37,7 @@ class TempHumDelegate(DefaultDelegate):
 	def handleDiscovery(self, dev, isNewDev, isNewData):
 		for (sdid, desc, val) in dev.getScanData():
 			if self.isTemperature(dev.addr, sdid, val):
+				logger.info(f"Discovery data from MAC: {dev.addr.upper()}")
 				bytes = [int(val[i:i+2], 16) for i in range(0, len(val), 2)]
 				temperature = (bytes[8] * 256 + bytes[9]) / 10
 				logger.info(f"Temp: {temperature}")
@@ -49,7 +50,7 @@ class TempHumDelegate(DefaultDelegate):
 				voltage = (bytes[12] * 256 + bytes[13]) / 1000
 				logger.info(f"Voltage: {voltage}")
 				for number, sensor in config.sensors.items():
-					if (sensor['MAC'] == dev.addr) and (sensor['UPDATED'] == False):
+					if (sensor['MAC'].upper() == dev.addr.upper()) and (sensor['UPDATED'] == False):
 						request_url = create_TH_request(config.DOMOTICZ_SERVER_IP,config.DOMOTICZ_SERVER_PORT,sensor['TH_IDX'],temperature,humidity,comfort_type,batteryLevel)
 						send_to_domoticz(request_url)
 						sensor['UPDATED'] = True


### PR DESCRIPTION
Hello, i've added small correction to your project.
Bluetooth device reported MAC address in lowercase, but in configuration as example it was showed as uppercase, so data was newer updated in discovery mode. Now i've added corrections to set all MAC addresses to uppercase, so no more issues there.